### PR TITLE
修复标签翻译bug

### DIFF
--- a/WebCrawler/__init__.py
+++ b/WebCrawler/__init__.py
@@ -283,8 +283,8 @@ def get_data_from_json(file_number, oCC):
         def convert_list(mapping_data,language,vars):
             total = []
             for i in vars:
-                if len(mapping_data.xpath('a[contains(@keyword, $name)]/@' + language, name=i)) != 0:
-                    i = mapping_data.xpath('a[contains(@keyword, $name)]/@' + language, name=i)[0]
+                if len(mapping_data.xpath('a[contains(@keyword, $name)]/@' + language, name=f",{i},")) != 0:
+                    i = mapping_data.xpath('a[contains(@keyword, $name)]/@' + language, name=f",{i},")[0]
                 total.append(i)
             return total
         def convert(mapping_data,language,vars):


### PR DESCRIPTION
'''mapping_data.xpath('a[contains(@keyword, $name)]/@' + language, name=i)[0]'''中使用了contains匹配，会导致原标签如“内S”错误命中标签“体内SJ”，因为他们也构成包含关系，xpath匹配时在name两侧添加逗号可解决该问题。